### PR TITLE
Adds starlight-links-validator dependency and fixes some broken links

### DIFF
--- a/.changeset/hip-mugs-call.md
+++ b/.changeset/hip-mugs-call.md
@@ -1,0 +1,5 @@
+---
+'starlight-videos-docs': patch
+---
+
+Adds `starlight-links-validator` dependency and fixes some broken links, namely `reference/actions` to `guides/actions`.

--- a/docs/astro.config.ts
+++ b/docs/astro.config.ts
@@ -1,6 +1,7 @@
 import starlight from '@astrojs/starlight'
 import { defineConfig } from 'astro/config'
 import starlightVideos from 'starlight-videos'
+import starlightLinksValidator from 'starlight-links-validator'
 
 export default defineConfig({
   integrations: [
@@ -9,7 +10,7 @@ export default defineConfig({
       editLink: {
         baseUrl: 'https://github.com/HiDeoo/starlight-videos/edit/main/docs/',
       },
-      plugins: [starlightVideos()],
+      plugins: [starlightVideos(), starlightLinksValidator()],
       sidebar: [
         {
           label: 'Start Here',

--- a/docs/package.json
+++ b/docs/package.json
@@ -18,6 +18,7 @@
     "@hideoo/starlight-plugins-docs-components": "^0.3.0",
     "astro": "^5.1.1",
     "sharp": "^0.33.5",
+    "starlight-links-validator": "^0.14.1",
     "starlight-videos": "workspace:*"
   },
   "engines": {

--- a/docs/src/content/docs/content/collection-video.md
+++ b/docs/src/content/docs/content/collection-video.md
@@ -130,7 +130,7 @@ video:
 
 ### `actions`
 
-**type:** [`StarlightVideosAction[]`](/reference/actions/)
+**type:** [`StarlightVideosAction[]`](/guides/actions/)
 
 Optional call-to-action links displayed below the video player.
-Check the [actions refernce](/reference/actions/) for more information.
+Check the [actions refernce](/guides/actions/) for more information.

--- a/docs/src/content/docs/content/video.md
+++ b/docs/src/content/docs/content/video.md
@@ -131,7 +131,7 @@ video:
 
 ### `actions`
 
-**type:** [`StarlightVideosAction[]`](/reference/actions/)
+**type:** [`StarlightVideosAction[]`](/guides/actions/)
 
 Optional call-to-action links displayed below the video player.
-Check the [actions refernce](/reference/actions/) for more information.
+Check the [actions refernce](/guides/actions/) for more information.

--- a/docs/src/content/docs/guides/actions.md
+++ b/docs/src/content/docs/guides/actions.md
@@ -28,7 +28,7 @@ video:
 
 ## Frontmatter fields
 
-Actions are defined in the [`actions`](#actions) field of the `video` frontmatter when the `type` is set to [`video`](/content/video/) or [`collection-video`](/content/collection-video/) and support the following fields:
+Actions are defined in the [`actions`](#create-actions) field of the `video` frontmatter when the `type` is set to [`video`](/content/video/) or [`collection-video`](/content/collection-video/) and support the following fields:
 
 ### `text`
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,9 @@ importers:
       sharp:
         specifier: ^0.33.5
         version: 0.33.5
+      starlight-links-validator:
+        specifier: ^0.14.1
+        version: 0.14.1(@astrojs/starlight@0.30.5(astro@5.1.1(jiti@2.4.2)(rollup@4.29.1)(typescript@5.7.2)(yaml@2.6.1)))
       starlight-videos:
         specifier: workspace:*
         version: link:../packages/starlight-videos
@@ -1066,6 +1069,9 @@ packages:
 
   '@types/normalize-package-data@2.4.4':
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
+
+  '@types/picomatch@3.0.1':
+    resolution: {integrity: sha512-1MRgzpzY0hOp9pW/kLRxeQhUWwil6gnrUYd3oEpeYBqp/FexhaCPv3F8LsYr47gtUU45fO2cm1dbwkSrHEo8Uw==}
 
   '@types/sax@1.2.7':
     resolution: {integrity: sha512-rO73L89PJxeYM3s3pPPjiPgVVcymqU490g0YO5n5By0k2Erzj6tay/4lr1CHAAU4JyOWd1rpQ8bCf6cZfHU96A==}
@@ -2225,6 +2231,10 @@ packages:
   iron-webcrypto@1.2.1:
     resolution: {integrity: sha512-feOM6FaSr6rEABp/eDfVseKyTMDt+KGpeB35SkVn9Tyn0CqvVsY3EwI0v5i8nMHyJnzCIQf7nsy3p41TPkJZhg==}
 
+  is-absolute-url@4.0.1:
+    resolution: {integrity: sha512-/51/TKE88Lmm7Gc4/8btclNXWS+g50wXhYJq8HWIBAGUBnoAdRu1aXeh364t/O7wXDAcTJDP8PNuNKWUDWie+A==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
   is-alphabetical@2.0.1:
     resolution: {integrity: sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==}
 
@@ -3331,6 +3341,12 @@ packages:
 
   stable-hash@0.0.4:
     resolution: {integrity: sha512-LjdcbuBeLcdETCrPn9i8AYAZ1eCtu4ECAWtP7UleOiZ9LzVxRzzUZEoZ8zB24nhkQnDWyET0I+3sWokSDS3E7g==}
+
+  starlight-links-validator@0.14.1:
+    resolution: {integrity: sha512-qd5zMBezFhE3R/RBW2am58jVMK3ydcHs8TqOOBLimjn+iXqWV/ZkLlpcavoIOd//w72cX3L//lN4TA+a7vdaZg==}
+    engines: {node: '>=18.17.1'}
+    peerDependencies:
+      '@astrojs/starlight': '>=0.15.0'
 
   starlight-package-managers@0.8.1:
     resolution: {integrity: sha512-a+zGIOdbN7B4T/VaszuvW8585Aau4LSU8HlVCmBCJJwxkrGAUC9lRya4y0md5tOAFyW/gfhUNJZM8qqyMNTe7Q==}
@@ -4932,6 +4948,8 @@ snapshots:
   '@types/node@17.0.45': {}
 
   '@types/normalize-package-data@2.4.4': {}
+
+  '@types/picomatch@3.0.1': {}
 
   '@types/sax@1.2.7':
     dependencies:
@@ -6590,6 +6608,8 @@ snapshots:
 
   iron-webcrypto@1.2.1: {}
 
+  is-absolute-url@4.0.1: {}
+
   is-alphabetical@2.0.1: {}
 
   is-alphanumerical@2.0.1:
@@ -8116,6 +8136,19 @@ snapshots:
   srt-parser-2@1.2.3: {}
 
   stable-hash@0.0.4: {}
+
+  starlight-links-validator@0.14.1(@astrojs/starlight@0.30.5(astro@5.1.1(jiti@2.4.2)(rollup@4.29.1)(typescript@5.7.2)(yaml@2.6.1))):
+    dependencies:
+      '@astrojs/starlight': 0.30.5(astro@5.1.1(jiti@2.4.2)(rollup@4.29.1)(typescript@5.7.2)(yaml@2.6.1))
+      '@types/picomatch': 3.0.1
+      github-slugger: 2.0.0
+      hast-util-from-html: 2.0.3
+      hast-util-has-property: 3.0.0
+      is-absolute-url: 4.0.1
+      kleur: 4.1.5
+      mdast-util-to-string: 4.0.0
+      picomatch: 4.0.2
+      unist-util-visit: 5.0.0
 
   starlight-package-managers@0.8.1(@astrojs/starlight@0.30.5(astro@5.1.1(jiti@2.4.2)(rollup@4.29.1)(typescript@5.7.2)(yaml@2.6.1))):
     dependencies:


### PR DESCRIPTION
**Describe the pull request**

I have added the [`starlight-links-validator` plugin](https://github.com/HiDeoo/starlight-links-validator) as a dependency and fixed some of the broken links it found.

I think I also found a "bug" in the starlight-links-validator, but I'm gonna report it in the other repo...